### PR TITLE
Make the rails version in the gemspec more restrictive

### DIFF
--- a/transam_spatial.gemspec
+++ b/transam_spatial.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency 'rails', '>=4.0.9'
+  s.add_dependency 'rails', '~> 4.1.9'
   s.add_dependency "geocoder"
 
   s.add_development_dependency "georuby", '~> 2.2.1'


### PR DESCRIPTION
Part of a group of changes, addressing the problem that TransAM Engine dependencies were breaking bundler. Pull them in this order so that travis can confirm the changes work:

* spatial
* audit
* lib
* sign
* accounting
* cpt
* funding
